### PR TITLE
Fix intermittent non-zero return code

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -2,7 +2,7 @@
 # setup tasks for ansible-role-vim.
 
 - name: Get Vim version.
-  ansible.builtin.shell: "set -o pipefail && vim --version | head -n1 | awk '{ print $5 }'"
+  ansible.builtin.shell: "set -o pipefail && (vim --version | head -n1 | awk '{ print $5 }') || test $? -eq 141"
   args:
     executable: "/bin/bash"
     warn: false


### PR DESCRIPTION
`head` occasionally closes the pipe before `vim --version` finishes writing to it, causing the command to fail with return code 141 (exit due to SIGPIPE). An explicit `test` for code 141 ignores that without squashing other errors.