### PR TITLE
Remove warn argument to ansible.builtin.shell

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -5,7 +5,6 @@
   ansible.builtin.shell: "set -o pipefail && (vim --version | head -n1 | awk '{ print $5 }') || test $? -eq 141"
   args:
     executable: "/bin/bash"
-    warn: false
   register: vim_version_string
   changed_when: false
 


### PR DESCRIPTION
It looks like newer versions of ansible have removed the `warn` option to `ansible.builtin.shell`. The error message from ansible 2.14.0 on Fedora 37 is as follows:

```
Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: chdir, _uses_shell, stdin_add_newline, _raw_params, strip_empty_ends, stdin, executable, argv, removes, creates.
```