### PR TITLE
Drop curly braces in when statement

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -11,7 +11,7 @@
 - name: Make sure it even makes sense to continue.
   ansible.builtin.fail:
     msg: "Vim does not support native package management in versions lower than 8.0."
-  when: vim_version_string.stdout is version('8.0', '<')
+  when: "vim_version_string.stdout is version('8.0', '<')"
 
 - name: Determine home directory.
   ansible.builtin.set_fact:

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -11,7 +11,7 @@
 - name: Make sure it even makes sense to continue.
   ansible.builtin.fail:
     msg: "Vim does not support native package management in versions lower than 8.0."
-  when: "{{ vim_version_string.stdout is version('8.0', '<') }}"
+  when: vim_version_string.stdout is version('8.0', '<')
 
 - name: Determine home directory.
   ansible.builtin.set_fact:


### PR DESCRIPTION
Avoids the following warning:

```
TASK [ansible-role-vim : Make sure it even makes sense to continue.] ******************************************************
[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{
vim_version_string.stdout is version('8.0', '<') }}
skipping: [127.0.0.1]
```

this is with:

```
(venv) hax0r@macos-macbook-local macos-deploy$ ansible --version
ansible [core 2.15.9]
  config file = /Users/hax0r/macos-deploy/ansible.cfg
  configured module search path = ['/Users/hax0r/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/hax0r/macos-deploy/venv/lib/python3.9/site-packages/ansible
  ansible collection location = /Users/hax0r/.ansible/collections:/usr/share/ansible/collections
  executable location = /Users/hax0r/macos-deploy/venv/bin/ansible
  python version = 3.9.6 (default, Nov 10 2023, 13:38:27) [Clang 15.0.0 (clang-1500.1.0.2.5)] (/Users/hax0r/macos-deploy/venv/bin/python3)
  jinja version = 3.1.3
  libyaml = True
```
