### PR TITLE
Allow setting plugin name

### DIFF
--- a/tasks/install-plugin.yml
+++ b/tasks/install-plugin.yml
@@ -3,15 +3,9 @@
 #
 # Installs one plugin.
 
-- name: Use supplied plugin name.
-  when: vim_plugin_install.name is defined
-  ansible.builtin.set_fact:
-    vim_plugin_name: "{{ vim_plugin_install.name }}"
-
 - name: Determine plugin name.
-  when: vim_plugin_install.name is undefined
   ansible.builtin.set_fact:
-    vim_plugin_name: "{{ (vim_plugin_install.repo | basename | splitext)[0] }}"
+    vim_plugin_name: "{{ vim_plugin_install.name | default((vim_plugin_install.repo | basename | splitext)[0]) }}"
 
 - name: Determine plugin install directory.
   ansible.builtin.set_fact:

--- a/tasks/install-plugin.yml
+++ b/tasks/install-plugin.yml
@@ -3,7 +3,13 @@
 #
 # Installs one plugin.
 
+- name: Use supplied plugin name.
+  when: vim_plugin_install.name is defined
+  ansible.builtin.set_fact:
+    vim_plugin_name: "{{ vim_plugin_install.name }}"
+
 - name: Determine plugin name.
+  when: vim_plugin_install.name is undefined
   ansible.builtin.set_fact:
     vim_plugin_name: "{{ (vim_plugin_install.repo | basename | splitext)[0] }}"
 


### PR DESCRIPTION
Very nice little ansible role!

I added a small feature - allowing to set the name of the plugin instead of using the basename of the git repo. This is handy if the plugin's repo is named something silly like "vim" - for example, [the dracula plugin](https://github.com/dracula/vim).

I'm not quite an expert at ansible, so there might be a better way to do this. Happy to iterate with feedback!