### PR TITLE
Only check to continue if version check was run

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -11,7 +11,7 @@
 - name: Make sure it even makes sense to continue.
   ansible.builtin.fail:
     msg: "Vim does not support native package management in versions lower than 8.0."
-  when: "{{ vim_version_string.stdout is version('8.0', '<') }}"
+  when: vim_version_string is not skipped and vim_version_string.stdout is version('8.0', '<')
 
 - name: Determine home directory.
   ansible.builtin.set_fact:

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -6,12 +6,13 @@
   args:
     executable: "/bin/bash"
   register: vim_version_string
+  check_mode: false
   changed_when: false
 
 - name: Make sure it even makes sense to continue.
   ansible.builtin.fail:
     msg: "Vim does not support native package management in versions lower than 8.0."
-  when: vim_version_string is not skipped and vim_version_string.stdout is version('8.0', '<')
+  when: "{{ vim_version_string.stdout is version('8.0', '<') }}"
 
 - name: Determine home directory.
   ansible.builtin.set_fact:


### PR DESCRIPTION
I got another fix for you. This one skips the "Make sure it even makes sense to continue" check if "Get Vim version" is skipped. This makes it so running the playbook in --check mode succeeds.

Note, this rolls in the change from #29.