### PR TITLE
Option to `become` when installing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The following variables are used in the role. See also Example Playbook
 
 | Variable name | Default value | Description |
 |---------------|---------------|-------------|
+| `vim_become` | `false` | Whether to `become` when installing packages. |
 | `vim_installed_packages`      | `["vim"]`         | A list of packages to install (passed to Ansible's Package module). |
 | `vim_removed_packages`        | `[]`              | A list of packages to remove (e.g. on Ubuntu, it might be preferable to remove `vim-tiny`). |
 | `vim_owner`                   | `""`              | The system user to install Vim and/or associated plugins for. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # defaults file for ansible-role-vim
 
+vim_become: false
 vim_installed_packages:
   - "vim"
 vim_removed_packages: []

--- a/tasks/manage-packages.yml
+++ b/tasks/manage-packages.yml
@@ -2,11 +2,13 @@
 # package-related tasks for ansible-role-vim.
 
 - name: Remove unneeded Vim-related packages.
+  become: "{{ vim_become }}"
   ansible.builtin.package:
     name: "{{ vim_removed_packages }}"
     state: absent
 
 - name: Install required Vim and Vim-related packages.
+  become: "{{ vim_become }}"
   ansible.builtin.package:
     name: "{{ vim_installed_packages }}"
     state: present


### PR DESCRIPTION
I have a system where you have to set `become: true` in order to install system packages. This lets you enable it optionally.